### PR TITLE
T/55: Mgit status should highlight all non-master rows

### DIFF
--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -11,7 +11,7 @@ const gitStatusParser = require( '../utils/gitstatusparser' );
 
 module.exports = {
 	beforeExecute() {
-		console.log( chalk.blue( 'Collecting statuses from all found packages...' ) );
+		console.log( chalk.blue( 'Collecting package statuses...' ) );
 	},
 
 	/**

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -86,8 +86,12 @@ module.exports = {
 			const wholeRow = [];
 			const statusColumn = [];
 
-			const wholeRowColor = mgitBranch !== status.branch ? 'magenta' : null;
+			const wholeRowColor = status.branch !== 'master' ? 'magenta' : null;
 			let branch = status.branch;
+
+			if ( mgitBranch !== status.branch ) {
+				branch = `${ color( 'cyan', '!' ) } ${ branch }`;
+			}
 
 			if ( status.ahead ) {
 				branch += color( 'yellow', ` ↑${ status.ahead }` );
@@ -122,7 +126,9 @@ module.exports = {
 				`${ color( 'yellow', '↑' ) } branch is ahead ${ color( 'yellow', '↓' ) } or behind`,
 				`${ color( 'green', '+' ) } staged files`,
 				`${ color( 'red', 'M' ) } modified files`,
-				`${ color( 'blue', '?' ) } untracked files`
+				`${ color( 'blue', '?' ) } untracked files`,
+				`\n${ color( 'cyan', '!' ) } current branch is other than specified in "mgit.json"`,
+				'highlighted row means the branch is other than "master"'
 			];
 
 			return `${ chalk.bold( 'Legend:' ) }\n${ legend.join( ', ' ) }.`;

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -11,7 +11,7 @@ const gitStatusParser = require( '../utils/gitstatusparser' );
 
 module.exports = {
 	beforeExecute() {
-		console.log( chalk.blue( 'Collecting package statuses...' ) );
+		console.log( chalk.blue( 'Collecting statuses...' ) );
 	},
 
 	/**
@@ -127,8 +127,7 @@ module.exports = {
 				`${ color( 'green', '+' ) } staged files`,
 				`${ color( 'red', 'M' ) } modified files`,
 				`${ color( 'blue', '?' ) } untracked files`,
-				`\n${ color( 'cyan', '!' ) } current branch is other than specified in "mgit.json"`,
-				'highlighted row means the branch is other than "master"'
+				`\n${ color( 'cyan', '!' ) } not on branch specified in "mgit.json"`
 			];
 
 			return `${ chalk.bold( 'Legend:' ) }\n${ legend.join( ', ' ) }.`;

--- a/tests/commands/status.js
+++ b/tests/commands/status.js
@@ -283,11 +283,7 @@ describe( 'commands/status', () => {
 
 			expect( logStub.calledTwice ).to.equal( true );
 			expect( logStub.firstCall.args[ 0 ] ).to.equal( '┻━┻' );
-			expect( logStub.secondCall.args[ 0 ] ).to.equal(
-				'Legend:\n' +
-				'↑ branch is ahead ↓ or behind, + staged files, M modified files, ? untracked files, \n' +
-				'! current branch is other than specified in "mgit.json", highlighted row means the branch is other than "master".'
-			);
+			expect( logStub.secondCall.args[ 0 ] ).to.match( /^Legend:/ );
 			expect( stubs.chalk.cyan.calledOnce ).to.equal( true );
 
 			logStub.restore();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved UI of the displayed table with statuses with repositories. Closes #55.

* If current branch is other than specified in `mgit.json` – the branch will be prefixed with `!`,
* If current branch is other than `master` – the whole row will be highlighted (in pink).