### PR TITLE
T/58: Status command failed to read status of repo in which files were removed

### DIFF
--- a/lib/utils/gitstatusparser.js
+++ b/lib/utils/gitstatusparser.js
@@ -34,7 +34,7 @@ module.exports = function gitStatusParser( response ) {
 
 	const branch = branchData.split( '...' )[ 0 ].match( /## (.*)$/ )[ 1 ];
 	const added = findFiles( [ ADDED_STAGED_SYMBOL ] );
-	const modified = findFiles( [ MODIFIED_NOT_STAGED_SYMBOL, MODIFIED_STAGED_AND_NOT_STAGED_SYMBOL ] );
+	const modified = findFiles( [ MODIFIED_NOT_STAGED_SYMBOL, MODIFIED_STAGED_AND_NOT_STAGED_SYMBOL, DELETE_NOT_STAGED_SYMBOL ] );
 	const deleted = findFiles( [ DELETE_STAGED_SYMBOL, DELETE_NOT_STAGED_SYMBOL ] );
 	const renamed = findFiles( [ RENAMED_STAGED_SYMBOL ] );
 	const unmerged = findFiles( UNMERGED_SYMBOLS );

--- a/tests/utils/gitstatusparser.js
+++ b/tests/utils/gitstatusparser.js
@@ -63,8 +63,10 @@ describe( 'utils', () => {
 			const status = gitStatusParser( gitStatusResponse );
 
 			expect( status.modified ).to.deep.equal( [
+				'README.txt',
 				'lib/index.js',
-				'lib/tasks/logger.js'
+				'lib/tasks/logger.js',
+				'lib/tasks/.gitkeep'
 			] );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Not staged, deleted files were not shown as modified during `mgit status` command. Closes #58.
