### PR TITLE
Packages will be sorted in order by alphabetical

### DIFF
--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -75,7 +75,18 @@ module.exports = {
 			}
 		} );
 
-		for ( const singleResponse of commandResponses.values() ) {
+		const packagesResponses = Array.from( commandResponses.values() )
+			.sort( ( a, b ) => {
+				if ( a.packageName < b.packageName ) {
+					return -1;
+				} else if ( a.packageName > b.packageName ) {
+					return 1;
+				}
+
+				return 0;
+			} );
+
+		for ( const singleResponse of packagesResponses ) {
 			table.push( createSingleRow( singleResponse ) );
 		}
 

--- a/tests/commands/status.js
+++ b/tests/commands/status.js
@@ -378,5 +378,47 @@ describe( 'commands/status', () => {
 
 			logStub.restore();
 		} );
+
+		it( 'sorts packages by alphabetically', () => {
+			const logStub = sandbox.stub( console, 'log' );
+
+			const processedPackages = new Set();
+			const commandResponses = new Set();
+
+			processedPackages.add( '@ckeditor/ckeditor5-foo' );
+			processedPackages.add( '@ckeditor/ckeditor5-bar' );
+			processedPackages.add( '@ckeditor/ckeditor5-bom' );
+			processedPackages.add( '@ckeditor/ckeditor5-aaa' );
+
+			commandResponses.add( getCommandResponse( 'foo', '1111111' ) );
+			commandResponses.add( getCommandResponse( 'bar', '2222222' ) );
+			commandResponses.add( getCommandResponse( 'bom', '3333333' ) );
+			commandResponses.add( getCommandResponse( 'aaa', '4444444' ) );
+
+			statusCommand.afterExecute( processedPackages, commandResponses );
+
+			expect( stubs.table.push.getCall( 0 ).args[ 0 ][ 0 ], 1 ).to.equal( 'aaa' );
+			expect( stubs.table.push.getCall( 1 ).args[ 0 ][ 0 ], 2 ).to.equal( 'bar' );
+			expect( stubs.table.push.getCall( 2 ).args[ 0 ][ 0 ], 3 ).to.equal( 'bom' );
+			expect( stubs.table.push.getCall( 3 ).args[ 0 ][ 0 ], 4 ).to.equal( 'foo' );
+
+			logStub.restore();
+
+			function getCommandResponse( packageName, commit ) {
+				return {
+					packageName,
+					status: {
+						branch: 'master',
+						ahead: 0,
+						behind: 0,
+						staged: [],
+						modified: [],
+						untracked: [],
+					},
+					mgitBranch: 'master',
+					commit
+				};
+			}
+		} );
 	} );
 } );

--- a/tests/commands/status.js
+++ b/tests/commands/status.js
@@ -272,11 +272,12 @@ describe( 'commands/status', () => {
 					compact: true
 				}
 			} );
+
 			expect( stubs.table.push.firstCall.args[ 0 ] ).to.deep.equal(
-				[ 'foo', 'master ↓2', 'abcd123', 'M1' ]
+				[ 'bar', 't/1 ↑3', 'ef45678', '+1 ?1' ]
 			);
 			expect( stubs.table.push.secondCall.args[ 0 ] ).to.deep.equal(
-				[ 'bar', 't/1 ↑3', 'ef45678', '+1 ?1' ]
+				[ 'foo', 'master ↓2', 'abcd123', 'M1' ]
 			);
 
 			expect( stubs.table.toString.calledOnce ).to.equal( true );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Packages displayed in a table (`mgit status`) will be sorted in order by alphabetical. Closes #60.
