### PR TITLE
Escape whitespace in package path

### DIFF
--- a/lib/utils/getoptions.js
+++ b/lib/utils/getoptions.js
@@ -34,7 +34,7 @@ module.exports = function cwdResolver( callOptions, cwd ) {
 
 	options = Object.assign( options, callOptions );
 
-	options.packages = path.resolve( cwd, options.packages );
+	options.packages = path.resolve( cwd, options.packages ).replace(/ /g, '\\ ');
 
 	return options;
 };


### PR DESCRIPTION
Fix: Escapes whitespace in `cwd` paths. Closes #74.

---

### Additional information

- This is a simple patch to add an escape character to any space found in the `options.packages` path. Fixes #74.
- It may be beneficial to escape the `cwd` further up the chain than in this specific option. However, that _may_ interfere with node path commands (not sure how they cope with escapes).