### PR TITLE
Coveralls.io instead of CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
   - node_modules
 install:
   - npm install
-  - npm install codeclimate-test-reporter
+  - npm install coveralls
 script:
   - npm run lint
   - npm run coverage
 after_success:
-  - node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://www.npmjs.com/package/mgit2"><img src="https://img.shields.io/npm/v/mgit2.svg" alt="mgit2 npm package badge"></a>
 <a href="https://travis-ci.org/cksource/mgit2"><img src="https://img.shields.io/travis/cksource/mgit2/master.svg" alt="build status badge"></a>
-<a href="https://codeclimate.com/github/cksource/mgit2/coverage"><img src="https://img.shields.io/codeclimate/coverage/github/cksource/mgit2.svg" alt="mgit2 coverage badge"></a>
+<a href="https://coveralls.io/github/cksource/mgit2?branch=master"><img src="https://coveralls.io/repos/github/cksource/mgit2/badge.svg?branch=master" alt="Coverage Status"></a>
 <a href="https://david-dm.org/cksource/mgit2"><img src="https://img.shields.io/david/cksource/mgit2.svg" alt="mgit2 dependencies status badge"></a>
 <a href="https://david-dm.org/cksource/mgit2?type=dev"><img src="https://img.shields.io/david/dev/cksource/mgit2.svg" alt="mgit2 devDependencies status badge"></a>
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed CodeClimate integration. Introduced Coveralls.io instead. Closes #70.