### PR TITLE
Introduced a smarter CWD resolver

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const chalk = require( 'chalk' );
 const exec = require( '../utils/exec' );
 

--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const exec = require( '../utils/exec' );
 
 module.exports = {

--- a/lib/commands/savehashes.js
+++ b/lib/commands/savehashes.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const path = require( 'path' );
+const path = require( 'upath' );
 const updateJsonFile = require( '../utils/updatejsonfile' );
 
 module.exports = {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const chalk = require( 'chalk' );
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const path = require( 'path' );
+const path = require( 'upath' );
 const createForkPool = require( './utils/createforkpool' );
 const logDisplay = require( './utils/displaylog' );
 const getOptions = require( './utils/getoptions' );

--- a/lib/utils/getcwd.js
+++ b/lib/utils/getcwd.js
@@ -5,13 +5,30 @@
 
 'use strict';
 
+const fs = require( 'fs' );
+const path = require( 'upath' );
+
 /**
  * Returns an absolute path to the directory with configuration file.
+ *
+ * It scans directory tree up for `mgit.json` file. If the file won't be found,
+ * an exception has been thrown.
  *
  * @returns {String}
  */
 module.exports = function cwdResolver() {
-	// TODO: Try to find path to the configuration file based on cwd.
+	let cwd = process.cwd();
 
-	return process.cwd();
+	while ( !fs.existsSync( path.join( cwd, 'mgit.json' ) ) ) {
+		const parentCwd = path.resolve( cwd, '..' );
+
+		if ( cwd === parentCwd ) {
+			throw new Error( 'Cannot find the "mgit.json" file.' );
+		}
+
+		cwd = parentCwd;
+	}
+
+	// Escapes all spaces in resolved cwd path.
+	return cwd.replace( / /g, '\\ ' );
 };

--- a/lib/utils/getoptions.js
+++ b/lib/utils/getoptions.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 
 /**
  * @param {Object} Call options.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "generic-pool": "^3.4.1",
     "meow": "^4.0.0",
     "minimatch": "^3.0.4",
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.1",
+    "upath": "^1.0.4"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-env": "^8.0.5",

--- a/tests/commands/bootstrap.js
+++ b/tests/commands/bootstrap.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 const expect = require( 'chai' ).expect;

--- a/tests/commands/exec.js
+++ b/tests/commands/exec.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 const expect = require( 'chai' ).expect;
@@ -86,8 +86,6 @@ describe( 'commands/exec', () => {
 						throw new Error( 'Supposed to be rejected.' );
 					},
 					response => {
-						expect( stubs.path.join.calledOnce ).to.equal( true );
-
 						const err = 'Package "test-package" is not available. Run "mgit bootstrap" in order to download the package.';
 						expect( response.logs.error[ 0 ] ).to.equal( err );
 					}

--- a/tests/commands/savehashes.js
+++ b/tests/commands/savehashes.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const path = require( 'path' );
+const path = require( 'upath' );
 const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 const expect = require( 'chai' ).expect;

--- a/tests/commands/update.js
+++ b/tests/commands/update.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 const expect = require( 'chai' ).expect;

--- a/tests/default-resolver.js
+++ b/tests/default-resolver.js
@@ -10,7 +10,7 @@
 const resolver = require( '../lib/default-resolver' );
 const getOptions = require( '../lib/utils/getoptions' );
 const expect = require( 'chai' ).expect;
-const cwd = require( 'path' ).resolve( __dirname, 'fixtures', 'project-a' );
+const cwd = require( 'upath' ).resolve( __dirname, 'fixtures', 'project-a' );
 
 describe( 'default resolver()', () => {
 	describe( 'with default options', () => {

--- a/tests/utils/getcwd.js
+++ b/tests/utils/getcwd.js
@@ -1,0 +1,69 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* jshint mocha:true */
+
+'use strict';
+
+const fs = require( 'fs' );
+const getCwd = require( '../../lib/utils/getcwd' );
+const expect = require( 'chai' ).expect;
+const sinon = require( 'sinon' );
+
+describe( 'utils', () => {
+	let sandbox;
+
+	beforeEach( () => {
+		sandbox = sinon.sandbox.create();
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+	} );
+	describe( 'getCwd()', () => {
+		it( 'returns "process.cwd()" value if the "mgit.json" has been found', () => {
+			sandbox.stub( process, 'cwd' ).returns( '/workspace/ckeditor/ckeditor5' );
+			sandbox.stub( fs, 'existsSync' ).returns( true );
+
+			expect( getCwd() ).to.equal( '/workspace/ckeditor/ckeditor5' );
+		} );
+
+		it( 'scans dir tree up in order to find "mgit.json" file', () => {
+			sandbox.stub( process, 'cwd' ).returns( '/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor' );
+
+			const existsSync = sandbox.stub( fs, 'existsSync' );
+
+			// /workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor
+			existsSync.onCall( 0 ).returns( false );
+			// /workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules
+			existsSync.onCall( 1 ).returns( false );
+			// /workspace/ckeditor/ckeditor5/packages/ckeditor5-engine
+			existsSync.onCall( 2 ).returns( false );
+			// /workspace/ckeditor/ckeditor5/packages
+			existsSync.onCall( 3 ).returns( false );
+			// /workspace/ckeditor/ckeditor5
+			existsSync.onCall( 4 ).returns( true );
+
+			expect( getCwd() ).to.equal( '/workspace/ckeditor/ckeditor5' );
+
+			expect( existsSync.getCall( 0 ).args[ 0 ] ).to.equal(
+				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/@ckeditor/mgit.json'
+			);
+			expect( existsSync.getCall( 1 ).args[ 0 ] ).to.equal(
+				'/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/node_modules/mgit.json'
+			);
+			expect( existsSync.getCall( 2 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/mgit.json' );
+			expect( existsSync.getCall( 3 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/packages/mgit.json' );
+			expect( existsSync.getCall( 4 ).args[ 0 ] ).to.equal( '/workspace/ckeditor/ckeditor5/mgit.json' );
+		} );
+
+		it( 'escapes the spaces in the returned path', () => {
+			sandbox.stub( process, 'cwd' ).returns( '/workspace/ckeditor copy/ckeditor5 fork' );
+			sandbox.stub( fs, 'existsSync' ).returns( true );
+
+			expect( getCwd() ).to.equal( '/workspace/ckeditor\\ copy/ckeditor5\\ fork' );
+		} );
+	} );
+} );

--- a/tests/utils/getoptions.js
+++ b/tests/utils/getoptions.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const getOptions = require( '../../lib/utils/getoptions' );
-const path = require( 'path' );
+const path = require( 'upath' );
 const expect = require( 'chai' ).expect;
 const cwd = path.resolve( __dirname, '..', 'fixtures', 'project-a' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced a smarter `cwd` resolver which scans directory tree up in order to find `mgit.json` file. If the file won't be found, an exception has been thrown. Closes #1.

NOTE: Replaced a built-in `path` module with `upath` in order to avoid having problems on Windows environments due to paths. From the `upath` docs: _Note that using Unix / on Windows works perfectly inside nodejs (and other languages), so there's no reason to stick to the Windows legacy at all._
