### PR TITLE
Space in path will not break the bootstrap command

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -32,8 +32,8 @@ module.exports = {
 			promise = Promise.resolve();
 		} else {
 			const command = [
-				`git clone --progress ${ data.repository.url } ${ destinationPath }`,
-				`cd ${ destinationPath }`,
+				`git clone --progress "${ data.repository.url }" "${ destinationPath }"`,
+				`cd "${ destinationPath }"`,
 				`git checkout --quiet ${ data.repository.branch }`
 			].join( ' && ' );
 

--- a/tests/commands/bootstrap.js
+++ b/tests/commands/bootstrap.js
@@ -88,9 +88,9 @@ describe( 'commands/bootstrap', () => {
 
 					// Clone the repository.
 					expect( cloneCommand[ 0 ] )
-						.to.equal( 'git clone --progress git@github.com/organization/test-package.git packages/test-package' );
+						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
 					// Change the directory to cloned package.
-					expect( cloneCommand[ 1 ] ).to.equal( 'cd packages/test-package' );
+					expect( cloneCommand[ 1 ] ).to.equal( 'cd "packages/test-package"' );
 					// And check out to proper branch.
 					expect( cloneCommand[ 2 ] ).to.equal( 'git checkout --quiet master' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: A space in a path will not break the bootstrap command. Closes #74.

Wrapped every path in quotation marks because they can contain a space that will break the command. 

---

It works.

![image](https://user-images.githubusercontent.com/2270764/39294014-d6280dcc-493a-11e8-9436-d4d3a6a3976d.png)