### PR TITLE
Bootstrap command will retry itself if failed

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -16,7 +16,7 @@ const command = {
 	 * @param {String} data.packageName Name of current package to process.
 	 * @param {Options} data.options The options object.
 	 * @param {Repository} data.repository
-	 * @param {Boolean} [data.doNotTryAgain=false] If set on true, bootstrap command won't be executed again.
+	 * @param {Boolean} [data.doNotTryAgain=false] If set to `true`, bootstrap command won't be executed again.
 	 * @returns {Promise}
 	 */
 	execute( data ) {

--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -10,17 +10,17 @@ const path = require( 'upath' );
 const chalk = require( 'chalk' );
 const exec = require( '../utils/exec' );
 
-module.exports = {
+const command = {
 	/**
 	 * @param {Object} data
 	 * @param {String} data.packageName Name of current package to process.
 	 * @param {Options} data.options The options object.
 	 * @param {Repository} data.repository
+	 * @param {Boolean} [data.doNotTryAgain=false] If set on true, bootstrap command won't be executed again.
 	 * @returns {Promise}
 	 */
 	execute( data ) {
 		const log = require( '../utils/log' )();
-
 		const destinationPath = path.join( data.options.packages, data.repository.directory );
 
 		let promise;
@@ -66,6 +66,16 @@ module.exports = {
 				return Promise.resolve( commandOutput );
 			} )
 			.catch( error => {
+				if ( isRemoteHungUpError( error ) && !data.doNotTryAgain ) {
+					const newData = Object.assign( {}, data, {
+						doNotTryAgain: true
+					} );
+
+					return delay( 5000 ).then( () => {
+						return command.execute( newData );
+					} );
+				}
+
 				log.error( error );
 
 				return Promise.reject( { logs: log.all() } );
@@ -79,3 +89,30 @@ module.exports = {
 		console.log( chalk.cyan( `${ processedPackages.size } packages have been processed.` ) );
 	}
 };
+
+module.exports = command;
+
+// See: https://github.com/cksource/mgit2/issues/87
+function isRemoteHungUpError( error ) {
+	if ( typeof error != 'string' ) {
+		error = error.toString();
+	}
+
+	const fatalErrors = error.split( '\n' )
+		.filter( message => message.startsWith( 'fatal:' ) )
+		.map( message => message.trim() );
+
+	if ( fatalErrors.length !== 3 ) {
+		return false;
+	}
+
+	return fatalErrors[ 0 ] == 'fatal: The remote end hung up unexpectedly' &&
+		fatalErrors[ 1 ] == 'fatal: early EOF' &&
+		fatalErrors[ 2 ] == 'fatal: index-pack failed';
+}
+
+function delay( ms ) {
+	return new Promise( resolve => {
+		setTimeout( resolve, ms );
+	} );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mgit2",
-  "version": "0.8.1--test-edition",
+  "version": "0.8.1",
   "description": "A tool for managing projects build using multiple repositories.",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mgit2",
-  "version": "0.8.1",
+  "version": "0.8.1--test-edition",
   "description": "A tool for managing projects build using multiple repositories.",
   "keywords": [
     "git",

--- a/tests/commands/bootstrap.js
+++ b/tests/commands/bootstrap.js
@@ -159,7 +159,7 @@ describe( 'commands/bootstrap', () => {
 
 					const firstCommand = stubs.exec.firstCall.args[ 0 ].split( ' && ' );
 
-					// Clone the repository.
+					// Clone the repository for the first time. It failed.
 					expect( firstCommand[ 0 ] )
 						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
 					// Change the directory to cloned package.
@@ -169,7 +169,7 @@ describe( 'commands/bootstrap', () => {
 
 					const secondCommand = stubs.exec.secondCall.args[ 0 ].split( ' && ' );
 
-					// Clone the repository.
+					// Clone the repository for the second time. It succeed.
 					expect( secondCommand[ 0 ] )
 						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
 					// Change the directory to cloned package.

--- a/tests/commands/bootstrap.js
+++ b/tests/commands/bootstrap.js
@@ -134,6 +134,52 @@ describe( 'commands/bootstrap', () => {
 					expect( response.packages ).to.deep.equal( [ 'test-bar' ] );
 				} );
 		} );
+
+		it( 'tries to install missing packages once again if git ends with unexpected error', function() {
+			this.timeout( 5500 );
+
+			stubs.fs.existsSync.returns( false );
+
+			stubs.exec.onFirstCall().returns( Promise.reject( [
+				'exec: Cloning into \'/some/path\'...',
+				'remote: Enumerating objects: 6, done.',
+				'remote: Counting objects: 100% (6/6), done.',
+				'remote: Compressing objects: 100% (6/6), done.',
+				'packet_write_wait: Connection to 000.00.000.000 port 22: Broken pipe',
+				'fatal: The remote end hung up unexpectedly',
+				'fatal: early EOF',
+				'fatal: index-pack failed'
+			].join( '\n' ) ) );
+
+			stubs.exec.onSecondCall().returns( Promise.resolve( 'Git clone log.' ) );
+
+			return bootstrapCommand.execute( data )
+				.then( response => {
+					expect( stubs.exec.calledTwice ).to.equal( true );
+
+					const firstCommand = stubs.exec.firstCall.args[ 0 ].split( ' && ' );
+
+					// Clone the repository.
+					expect( firstCommand[ 0 ] )
+						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
+					// Change the directory to cloned package.
+					expect( firstCommand[ 1 ] ).to.equal( 'cd "packages/test-package"' );
+					// And check out to proper branch.
+					expect( firstCommand[ 2 ] ).to.equal( 'git checkout --quiet master' );
+
+					const secondCommand = stubs.exec.secondCall.args[ 0 ].split( ' && ' );
+
+					// Clone the repository.
+					expect( secondCommand[ 0 ] )
+						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
+					// Change the directory to cloned package.
+					expect( secondCommand[ 1 ] ).to.equal( 'cd "packages/test-package"' );
+					// And check out to proper branch.
+					expect( secondCommand[ 2 ] ).to.equal( 'git checkout --quiet master' );
+
+					expect( response.logs.info[ 0 ] ).to.equal( 'Git clone log.' );
+				} );
+		} );
 	} );
 
 	describe( 'afterExecute()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced a mechanism which allows executing `bootstrap` command once again if it ends with an error. Closes #87.
