### PR TITLE
Simplified the error check

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -92,7 +92,7 @@ const command = {
 
 module.exports = command;
 
-// See: https://github.com/cksource/mgit2/issues/87
+// See: #87 and #92.
 function isRemoteHungUpError( error ) {
 	if ( typeof error != 'string' ) {
 		error = error.toString();
@@ -102,13 +102,7 @@ function isRemoteHungUpError( error ) {
 		.filter( message => message.startsWith( 'fatal:' ) )
 		.map( message => message.trim() );
 
-	if ( fatalErrors.length !== 3 ) {
-		return false;
-	}
-
-	return fatalErrors[ 0 ] == 'fatal: The remote end hung up unexpectedly' &&
-		fatalErrors[ 1 ] == 'fatal: early EOF' &&
-		fatalErrors[ 2 ] == 'fatal: index-pack failed';
+	return fatalErrors[ 0 ] && fatalErrors[ 0 ].match( /fatal: the remote end hung up unexpectedly/i );
 }
 
 function delay( ms ) {

--- a/tests/commands/bootstrap.js
+++ b/tests/commands/bootstrap.js
@@ -135,7 +135,7 @@ describe( 'commands/bootstrap', () => {
 				} );
 		} );
 
-		it( 'tries to install missing packages once again if git ends with unexpected error', function() {
+		it( 'tries to install missing packages once again if git ends with unexpected error (#1)', function() {
 			this.timeout( 5500 );
 
 			stubs.fs.existsSync.returns( false );
@@ -147,6 +147,52 @@ describe( 'commands/bootstrap', () => {
 				'remote: Compressing objects: 100% (6/6), done.',
 				'packet_write_wait: Connection to 000.00.000.000 port 22: Broken pipe',
 				'fatal: The remote end hung up unexpectedly',
+				'fatal: early EOF',
+				'fatal: index-pack failed'
+			].join( '\n' ) ) );
+
+			stubs.exec.onSecondCall().returns( Promise.resolve( 'Git clone log.' ) );
+
+			return bootstrapCommand.execute( data )
+				.then( response => {
+					expect( stubs.exec.calledTwice ).to.equal( true );
+
+					const firstCommand = stubs.exec.firstCall.args[ 0 ].split( ' && ' );
+
+					// Clone the repository for the first time. It failed.
+					expect( firstCommand[ 0 ] )
+						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
+					// Change the directory to cloned package.
+					expect( firstCommand[ 1 ] ).to.equal( 'cd "packages/test-package"' );
+					// And check out to proper branch.
+					expect( firstCommand[ 2 ] ).to.equal( 'git checkout --quiet master' );
+
+					const secondCommand = stubs.exec.secondCall.args[ 0 ].split( ' && ' );
+
+					// Clone the repository for the second time. It succeed.
+					expect( secondCommand[ 0 ] )
+						.to.equal( 'git clone --progress "git@github.com/organization/test-package.git" "packages/test-package"' );
+					// Change the directory to cloned package.
+					expect( secondCommand[ 1 ] ).to.equal( 'cd "packages/test-package"' );
+					// And check out to proper branch.
+					expect( secondCommand[ 2 ] ).to.equal( 'git checkout --quiet master' );
+
+					expect( response.logs.info[ 0 ] ).to.equal( 'Git clone log.' );
+				} );
+		} );
+
+		it( 'tries to install missing packages once again if git ends with unexpected error (#2)', function() {
+			this.timeout( 5500 );
+
+			stubs.fs.existsSync.returns( false );
+
+			stubs.exec.onFirstCall().returns( Promise.reject( [
+				'exec: Cloning into \'/some/path\'...',
+				'remote: Enumerating objects: 6, done.',
+				'remote: Counting objects: 100% (6/6), done.',
+				'remote: Compressing objects: 100% (6/6), done.',
+				'packet_write_wait: Connection to 000.00.000.000 port 22: Broken pipe',
+				'fatal: the remote end hung up unexpectedly',
 				'fatal: early EOF',
 				'fatal: index-pack failed'
 			].join( '\n' ) ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Simplified a check for "remote end hung up" error during the `bootstrap` command. Closes #92.