### PR TITLE
Introduced the "overrideDirectoryNames" option in a config

### DIFF
--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -49,8 +49,8 @@ module.exports = {
 			.then( ( [ hashResponse, statusResponse ] ) => {
 				let packageName = data.packageName;
 
-				if ( data.mgitOptions.packagesPrefix ) {
-					packageName = packageName.replace( data.mgitOptions.packagesPrefix, '' );
+				for ( const packagePrefix of data.mgitOptions.packagesPrefix ) {
+					packageName = packageName.replace( new RegExp( '^' + packagePrefix ), '' );
 				}
 
 				const commandResponse = {

--- a/lib/default-resolver.js
+++ b/lib/default-resolver.js
@@ -26,6 +26,10 @@ module.exports = function resolver( packageName, options ) {
 		defaultBranch: options.resolverDefaultBranch
 	} );
 
+	if ( options.overrideDirectoryNames[ packageName ] ) {
+		repository.directory = options.overrideDirectoryNames[ packageName ];
+	}
+
 	if ( options.resolverTargetDirectory == 'npm' ) {
 		repository.directory = packageName;
 	}

--- a/lib/utils/getoptions.js
+++ b/lib/utils/getoptions.js
@@ -82,6 +82,6 @@ module.exports = function cwdResolver( callOptions, cwd ) {
  *
  * @property {Object} [overrideDirectoryNames={}] A map that allows renaming directories where packages will be cloned.
  *
- * @property {String|Array.<String>|undefined} [packagesPrefix=[]] Prefix or prefixes which will be removed from packages' names during
+ * @property {String|Array.<String>} [packagesPrefix=[]] Prefix or prefixes which will be removed from packages' names during
  * printing the summary of the "status" command.
  */

--- a/lib/utils/getoptions.js
+++ b/lib/utils/getoptions.js
@@ -25,7 +25,9 @@ module.exports = function cwdResolver( callOptions, cwd ) {
 		resolverTargetDirectory: 'git',
 		resolverDefaultBranch: 'master',
 		ignore: null,
-		scope: null
+		scope: null,
+		packagesPrefix: [],
+		overrideDirectoryNames: {}
 	};
 
 	if ( fs.existsSync( mgitJsonPath ) ) {
@@ -35,6 +37,10 @@ module.exports = function cwdResolver( callOptions, cwd ) {
 	options = Object.assign( options, callOptions );
 
 	options.packages = path.resolve( cwd, options.packages );
+
+	if ( !Array.isArray( options.packagesPrefix ) ) {
+		options.packagesPrefix = [ options.packagesPrefix ];
+	}
 
 	return options;
 };
@@ -73,4 +79,9 @@ module.exports = function cwdResolver( callOptions, cwd ) {
  * If a string: name of branch that should be created.
  *
  * @property {Boolean|undefined} [hash=undefined] Whether to use current commit hashes as an input data.
+ *
+ * @property {Object} [overrideDirectoryNames={}] A map that allows renaming directories where packages will be cloned.
+ *
+ * @property {String|Array.<String>|undefined} [packagesPrefix=[]] Prefix or prefixes which will be removed from packages' names during
+ * printing the summary of the "status" command.
  */

--- a/tests/default-resolver.js
+++ b/tests/default-resolver.js
@@ -134,4 +134,28 @@ describe( 'default resolver()', () => {
 			} );
 		} );
 	} );
+
+	describe( 'with options.overrideDirectoryNames', () => {
+		it( 'returns package with modified directory', () => {
+			const options = getOptions( {}, cwd );
+
+			expect( resolver( 'override-directory', options ) ).to.deep.equal( {
+				url: 'git@github.com:foo/bar.git',
+				branch: 'master',
+				directory: 'custom-directory'
+			} );
+		} );
+
+		it( 'ignores modified directory if "resolverTargetDirectory" is set to "npm"', () => {
+			const options = getOptions( {
+				resolverTargetDirectory: 'npm'
+			}, cwd );
+
+			expect( resolver( 'override-directory', options ) ).to.deep.equal( {
+				url: 'git@github.com:foo/bar.git',
+				branch: 'master',
+				directory: 'override-directory'
+			} );
+		} );
+	} );
 } );

--- a/tests/fixtures/project-a/mgit.json
+++ b/tests/fixtures/project-a/mgit.json
@@ -5,6 +5,10 @@
     "@scoped/package": "c/d",
     "full-url-git": "git@github.com:cksource/mgit2.git",
     "full-url-git-with-branch": "git@github.com:cksource/mgit2.git#xyz",
-    "full-url-https": "https://github.com/cksource/mgit2.git"
+    "full-url-https": "https://github.com/cksource/mgit2.git",
+    "override-directory": "foo/bar"
+  },
+  "overrideDirectoryNames": {
+    "override-directory": "custom-directory"
   }
 }

--- a/tests/utils/getoptions.js
+++ b/tests/utils/getoptions.js
@@ -29,7 +29,11 @@ describe( 'utils', () => {
 				resolverTargetDirectory: 'git',
 				resolverDefaultBranch: 'master',
 				scope: null,
-				ignore: null
+				ignore: null,
+				packagesPrefix: [],
+				overrideDirectoryNames: {
+					'override-directory': 'custom-directory'
+				}
 			} );
 		} );
 
@@ -52,7 +56,9 @@ describe( 'utils', () => {
 				resolverTargetDirectory: 'git',
 				resolverDefaultBranch: 'master',
 				scope: null,
-				ignore: null
+				ignore: null,
+				packagesPrefix: [],
+				overrideDirectoryNames: {}
 			} );
 		} );
 
@@ -71,7 +77,9 @@ describe( 'utils', () => {
 				resolverTargetDirectory: 'git',
 				resolverDefaultBranch: 'master',
 				scope: null,
-				ignore: null
+				ignore: null,
+				packagesPrefix: [],
+				overrideDirectoryNames: {}
 			} );
 		} );
 
@@ -93,7 +101,9 @@ describe( 'utils', () => {
 				resolverTargetDirectory: 'git',
 				resolverDefaultBranch: 'master',
 				scope: null,
-				ignore: null
+				ignore: null,
+				packagesPrefix: [],
+				overrideDirectoryNames: {}
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced an option (`overrideDirectoryNames`) that allows modifying a directory where a package would be cloned. Closes #72.
