### PR TITLE
enable cloning from file urls (e.g. file:///workspace/myrepo/.git)

### DIFF
--- a/lib/utils/parserepositoryurl.js
+++ b/lib/utils/parserepositoryurl.js
@@ -24,7 +24,7 @@ module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 	const branch = parsedUrl.hash ? parsedUrl.hash.slice( 1 ) : options.defaultBranch;
 	let repoUrl;
 
-	if ( repositoryUrl.match( /^https?:\/\// ) || repositoryUrl.match( /^git@/ ) ) {
+	if ( repositoryUrl.match( /^file?:\/\/\// ) || repositoryUrl.match( /^https?:\/\// ) || repositoryUrl.match( /^git@/ ) ) {
 		parsedUrl.hash = null;
 
 		repoUrl = url.format( parsedUrl );
@@ -37,7 +37,7 @@ module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 	return {
 		url: repoUrl,
 		branch,
-		directory: repoUrl.match( /[:/]([^/]+)\.git$/ )[ 1 ]
+		directory: repoUrl.match( /[:/]([^/]+)\/?\.git$/ )[ 1 ]
 	};
 };
 

--- a/lib/utils/parserepositoryurl.js
+++ b/lib/utils/parserepositoryurl.js
@@ -13,18 +13,18 @@ const url = require( 'url' );
  *
  * @param {String} repositoryUrl The repository URL in formats supported by `mgit.json`.
  * @param {Object} options
- * @param {String} options.urlTemplate The URL template.
+ * @param {String} [options.urlTemplate] The URL template.
  * Used if `repositoryUrl` defines only `'<organization>/<repositoryName>'`.
- * @param {String} options.defaultBranch The default branch name to be used if the
+ * @param {String} [options.defaultBranch='master'] The default branch name to be used if the
  * repository URL doesn't specify it.
  * @returns {Repository}
  */
 module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 	const parsedUrl = url.parse( repositoryUrl );
-	const branch = parsedUrl.hash ? parsedUrl.hash.slice( 1 ) : options.defaultBranch;
+	const branch = parsedUrl.hash ? parsedUrl.hash.slice( 1 ) : options.defaultBranch || 'master';
 	let repoUrl;
 
-	if ( repositoryUrl.match( /^file?:\/\/\// ) || repositoryUrl.match( /^https?:\/\// ) || repositoryUrl.match( /^git@/ ) ) {
+	if ( repositoryUrl.match( /^(file|https?):\/\// ) || repositoryUrl.match( /^git@/ ) ) {
 		parsedUrl.hash = null;
 
 		repoUrl = url.format( parsedUrl );
@@ -37,7 +37,7 @@ module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 	return {
 		url: repoUrl,
 		branch,
-		directory: repoUrl.match( /[:/]([^/]+)\/?\.git$/ )[ 1 ]
+		directory: repoUrl.split( '/' ).reverse()[ 0 ].replace( /\.git$/, '' )
 	};
 };
 

--- a/lib/utils/parserepositoryurl.js
+++ b/lib/utils/parserepositoryurl.js
@@ -37,7 +37,7 @@ module.exports = function parseRepositoryUrl( repositoryUrl, options = {} ) {
 	return {
 		url: repoUrl,
 		branch,
-		directory: repoUrl.split( '/' ).reverse()[ 0 ].replace( /\.git$/, '' )
+		directory: repoUrl.replace( /\.git$/, '' ).match( /[:/]([^/]+)\/?$/ )[ 1 ]
 	};
 };
 

--- a/tests/utils/parserepositoryurl.js
+++ b/tests/utils/parserepositoryurl.js
@@ -1,0 +1,132 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* jshint mocha:true */
+
+'use strict';
+
+const expect = require( 'chai' ).expect;
+const parseRepositoryUrl = require( '../../lib/utils/parserepositoryurl' );
+
+describe( 'utils', () => {
+	describe( 'parseRepositoryUrl()', () => {
+		it( 'returns "master" branch if "options.defaultBranch" was not specified', () => {
+			const repository = parseRepositoryUrl( 'foo/bar', {
+				urlTemplate: 'https://github.com/${ path }.git'
+			} );
+
+			expect( repository ).to.deep.equal( {
+				url: 'https://github.com/foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'allows modifying the branch using hash in "<organization>/<repositoryName>" template', () => {
+			const repository = parseRepositoryUrl( 'foo/bar#stable', {
+				urlTemplate: 'https://github.com/${ path }.git'
+			} );
+
+			expect( repository ).to.deep.equal( {
+				url: 'https://github.com/foo/bar.git',
+				branch: 'stable',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'ignores "options.defaultBranch" if branch is defined in specified repository', () => {
+			const repository = parseRepositoryUrl( 'foo/bar#stable', {
+				urlTemplate: 'https://github.com/${ path }.git',
+				defaultBranch: 'master'
+			} );
+
+			expect( repository ).to.deep.equal( {
+				url: 'https://github.com/foo/bar.git',
+				branch: 'stable',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "http" URL', () => {
+			const repository = parseRepositoryUrl( 'http://github.com/foo/bar.git' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'http://github.com/foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "https" URL', () => {
+			const repository = parseRepositoryUrl( 'https://github.com/foo/bar.git' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'https://github.com/foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "file" (Unix) URL (ends with ".git")', () => {
+			const repository = parseRepositoryUrl( 'file:///Users/Workspace/Projects/foo/bar.git' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'file:///Users/Workspace/Projects/foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "file" (Unix) URL (ends does not with ".git")', () => {
+			const repository = parseRepositoryUrl( 'file:///Users/Workspace/Projects/foo/bar' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'file:///Users/Workspace/Projects/foo/bar',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "file" (Windows) URL (ends with ".git")', () => {
+			const repository = parseRepositoryUrl( 'file://C:/Users/Workspace/Projects/foo/bar.git' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'file://c/Users/Workspace/Projects/foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "file" (Windows) URL (ends does not with ".git")', () => {
+			const repository = parseRepositoryUrl( 'file://C:/Users/Workspace/Projects/foo/bar' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'file://c/Users/Workspace/Projects/foo/bar',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'extracts all parameters basing on specified "git" URL', () => {
+			const repository = parseRepositoryUrl( 'git@github.com:foo/bar.git' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'git@github.com:foo/bar.git',
+				branch: 'master',
+				directory: 'bar'
+			} );
+		} );
+
+		it( 'allows modifying the branch using hash in the URL', () => {
+			const repository = parseRepositoryUrl( 'https://github.com/foo/bar.git#stable' );
+
+			expect( repository ).to.deep.equal( {
+				url: 'https://github.com/foo/bar.git',
+				branch: 'stable',
+				directory: 'bar'
+			} );
+		} );
+	} );
+} );

--- a/tests/utils/parserepositoryurl.js
+++ b/tests/utils/parserepositoryurl.js
@@ -69,17 +69,7 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		it( 'extracts all parameters basing on specified "file" (Unix) URL (ends with ".git")', () => {
-			const repository = parseRepositoryUrl( 'file:///Users/Workspace/Projects/foo/bar.git' );
-
-			expect( repository ).to.deep.equal( {
-				url: 'file:///Users/Workspace/Projects/foo/bar.git',
-				branch: 'master',
-				directory: 'bar'
-			} );
-		} );
-
-		it( 'extracts all parameters basing on specified "file" (Unix) URL (ends does not with ".git")', () => {
+		it( 'extracts all parameters basing on specified "file" (Unix path)', () => {
 			const repository = parseRepositoryUrl( 'file:///Users/Workspace/Projects/foo/bar' );
 
 			expect( repository ).to.deep.equal( {
@@ -89,17 +79,7 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		it( 'extracts all parameters basing on specified "file" (Windows) URL (ends with ".git")', () => {
-			const repository = parseRepositoryUrl( 'file://C:/Users/Workspace/Projects/foo/bar.git' );
-
-			expect( repository ).to.deep.equal( {
-				url: 'file://c/Users/Workspace/Projects/foo/bar.git',
-				branch: 'master',
-				directory: 'bar'
-			} );
-		} );
-
-		it( 'extracts all parameters basing on specified "file" (Windows) URL (ends does not with ".git")', () => {
+		it( 'extracts all parameters basing on specified "file" (Windows path)', () => {
 			const repository = parseRepositoryUrl( 'file://C:/Users/Workspace/Projects/foo/bar' );
 
 			expect( repository ).to.deep.equal( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Allows cloning packages using the `file://` protocol. Closes #101.
