### PR TITLE
Print out repositories where an executed command failed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,9 @@ module.exports = function( args, options ) {
 
 				if ( packagesWithError.size ) {
 					const repositoryForm = packagesWithError.size === 1 ? 'repository' : 'repositories';
-					const message = `\n❗❗❗ The command failed to execute in ${ packagesWithError.size } ${ repositoryForm }.\n`;
+					let message = `\n❗❗❗ The command failed to execute in ${ packagesWithError.size } ${ repositoryForm }:\n`;
+					message += [ ...packagesWithError ].map( pkgName => `  - ${ pkgName }` ).join( '\n' );
+					message += '\n';
 
 					console.log( chalk.red( message ) );
 					process.exit( 1 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Repositories, where an executed command failed, will be printed out at the end of the mgit log. Closes #104.

---

![image](https://user-images.githubusercontent.com/2270764/61697654-0549b080-ad38-11e9-8d66-a60f779d6b0d.png)

